### PR TITLE
Added HackSquad Swag

### DIFF
--- a/data.json
+++ b/data.json
@@ -315,6 +315,15 @@
     "tags": ["clothing", "hacktoberfest", "stickers", "expired"]
   },
   {
+    "name": "HackSquad 2023",
+    "difficulty": "hard",
+    "description": "The top 60 squads will win awesome swag! around ~300 winners!",
+    "reference": "https://www.hacksquad.dev/#swag",
+    "image": "https://pbs.twimg.com/media/F3KWb-qaoAAlUT1?format=jpg&name=900x900",
+    "dateAdded": " 2023-10-11T17:20:16.000Z.",
+    "tags": ["clothing", "hacktoberfest", "stickers"]
+  },
+  {
     "name": "Hasura",
     "difficulty": "medium",
     "description": "Submit a PR to Hasura's <a href='https://github.com/hasura/graphql-engine'>GraphQL Engine</a> or <a href='https://github.com/hasura/learn-graphql'>GraphQL Tutorial Series</a> during Hacktoberfest 2020 and get a Hasura sticker pack. For all valid PRs closing an issue with the label hacktoberfest, a secret swag will be sent.",


### PR DESCRIPTION
Added Swag Opportunity for HackSquad

<!--
If you want to propose a new swag opportunity, please ensure you created an issue first and then head to:
https://github.com/swapagarwal/swag-for-dev/compare/master...swapagarwal:master?expand=1&template=new-swag-opportunity.md
-->

- [x] I've checked that this isn't a new swag opportunity proposal.
- [x] I've checked that this isn't a duplicate pull request.

<!-- Describe your changes below -->
I've added an opportunity to get swags from HackSquad by being in Top 60 Teams. 
This solves the issue <a href='https://github.com/swapagarwal/swag-for-dev/issues/1080'>#1080</a>


<!-- Thanks for contributing! -->
